### PR TITLE
Add GHC warning flags to bazel build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,6 +6,11 @@ project("hs-schema")
 haskell_library(
     name = "hs-schema",
     srcs = glob(["src/**/*.*hs"]),
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
     prebuilt_dependencies = ["base"],
     src_strip_prefix = "src",
 )


### PR DESCRIPTION
`-Werror` is fine here because we control the exact version of GHC we are
building with (currently 8.2.2), so there is no risk of getting different
warnings on different installations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-schema/11)
<!-- Reviewable:end -->
