### PR TITLE
Remove standard_travis setting in BUILD.bazel.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-project(standard_travis = True)
+project()
 
 haskell_library(
     name = "hs-schema",


### PR DESCRIPTION
This is becoming the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-schema/25)
<!-- Reviewable:end -->
