### PR TITLE
perf: Use StrictData for all modules that define data types.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.15
+    image: toxchat/toktok-stack:0.0.17
     cpu: 2
-    memory: 4G
+    memory: 6G
   configure_script:
     - /src/workspace/tools/inject-repo hs-schema
   test_all_script:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,7 +12,7 @@ branches:
     protection:
       required_status_checks:
         contexts:
-          - "Cabal Build / build (pull_request)"
+          - "build"
           - "cirrus-ci"
           - "Codacy Static Code Analysis"
           - "code-review/reviewable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: cabal haddock --haddock-for-hackage --enable-doc
 
       - name: Publish candidate to Hackage
+        if: ${{ github.event_name == 'push' }}
         env:
           API_TOKEN_HACKAGE: ${{ secrets.API_TOKEN_HACKAGE }}
         run: |

--- a/src/Data/Schema.hs
+++ b/src/Data/Schema.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StrictData        #-}
 module Data.Schema where
 
 import           Data.Proxy (Proxy)

--- a/test/Data/SchemaSpec.hs
+++ b/test/Data/SchemaSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData          #-}
 module Data.SchemaSpec (spec) where
 
 import           Control.Monad    (when)


### PR DESCRIPTION
I've added StrictData to some modules that don't currently define data
types, mostly by mistake, but it doesn't harm and avoids missing it in
the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-schema/31)
<!-- Reviewable:end -->
