### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,6 +8,7 @@ haskell_library(
     name = "hs-schema",
     srcs = glob(["src/**/*.*hs"]),
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     version = "0.0.4",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-schema/51)
<!-- Reviewable:end -->
